### PR TITLE
Fixed style, deprecation and correctness issues; Refactoring as prep for better API sep

### DIFF
--- a/openVulnQuery/README.md
+++ b/openVulnQuery/README.md
@@ -27,22 +27,46 @@ Obtain client ID and Secret:
   - Under OAuth2.0 Credentials check Client Credentials
   - Under Select APIs choose Cisco PSIRT openVuln API
   - Agree to the terms and service and click Register
-  - Edit CLIENT_ID and CLIENT_SECRET in the config file with the ones provided from the steps above.
-  - To edit the config.py file if installing with pip, run the command pip show openVulnQuery and cd into the location of the package. Then cd into the openVulnQuery folder and open the config.py file in your favorite editor, modify and save.
-  - OAuth2 Token automatically generated on each call to the API.
+5. Take note of the "rate contract" presented like e.g.:
+    ```
+    Rate Limits
+    10	Calls per second
+    5,000	Calls per day
+    ```
+6. Note the value of "Client ID" (a string like e.g. 'abc12abcd13abcdefabcde1a')
+7. Note the value of "Client Secret" (a string like e.g. '1a2abcDEfaBcDefAbcDeFA3b')
+8. Create a valid JSON file (e.g. `credentials.json`) with these personal credentials similar to the below given (assuming the values are as in steps 6. and 7.):
+    ```
+    {
+    	"CLIENT_ID": "abc12abcd13abcdefabcde1a", 
+    	"CLIENT_SECRET": "1a2abcDEfaBcDefAbcDeFA3b"
+    }
+    ```
+9. Do not distribute the credentials file resulting from previous step
+
+**Notes**: 
+* The resulting OAuth2 Token will be automatically generated on every call to the API.
 
 #### Run OpenVulnQuery in the Terminal
 - If installed with pip run the program by typing
 ```
-  >>OpenVulnQuery --Advisory Type --API Filters --Parsing Fields --Output Format -Count
+  >>OpenVulnQuery --config PathToCredentialsFile --Advisory Type --API Filters --Parsing Fields --Output Format -Count
 ```
 - Or cd into the directory with the main.py file and run using
 ```
-  >>python main.py --Advisory Type --API Filters --Parsing Fields --Output Format -Count
+  >>python main.py --config PathToCredentialsFile --Advisory Type --API Filters --Parsing Fields --Output Format -Count
 ```
 Notes:
 
 -- Used for whole word commands, - Used for single character commands
+
+#### Configuration (Required)
+```
+--config FILE
+        Path to JSON file with credentials (as in above step 8)
+        A sample has been provided in the same folder as main.py:
+            sample:configuration.json
+```
 
 #### Advisory Type (Required)
 ```
@@ -117,6 +141,14 @@ Notes:
         >> openVulnQuery --ios_xe 3.16.1S
 
 ```
+
+#### Client Application (Optional)
+```
+--user-agent APPLICATION
+        Name of application to be sent as User-Agent header value in the request.
+        Default is TestApp.
+```
+
 #### Parsing Fields (Optional)
 Notes:
 
@@ -146,31 +178,31 @@ Any field that has no information will return with with the field name and NA
 
         API Fields
               Examples:
-              openVulnQuery --cvrf or --oval --any API filter -f  or --fields list of fields separated by space
-              >> openVulnQuery --cvrf --all -f sir cves cvrf_url
-              >> openVulnQuery --cvrf --severity critical -f last_updated cves
-              >> openVulnQuery --oval --all -f sir cves oval_url
-              >> openVulnQuery --oval --severity critical -f last_updated cves
+              openVulnQuery --config PathToCredentialsFile --cvrf or --oval --any API filter -f  or --fields list of fields separated by space
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --all -f sir cves cvrf_url
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --severity critical -f last_updated cves
+              >> openVulnQuery --config PathToCredentialsFile --oval --all -f sir cves oval_url
+              >> openVulnQuery --config PathToCredentialsFile --oval --severity critical -f last_updated cves
 
         CVRF XML Fields
               Examples:
-              openVulnQuery --cvrf --any API filter -f or --fields list of fields separated by space
-              >> openVulnQuery --cvrf --all -f bug_ids vuln_title product_names
-              >> openVulnQuery --cvrf --severity critical -f bug_ids summary
+              openVulnQuery --config PathToCredentialsFile --cvrf --any API filter -f or --fields list of fields separated by space
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --all -f bug_ids vuln_title product_names
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --severity critical -f bug_ids summary
 
         Combination
               Examples:
-              openVulnQuery --cvrf --any API filter -f or --fields list of fields separated by space
-              >> openVulnQuery --cvrf --all -f sir bug_ids cves vuln_title
-              >> openVulnQuery --cvrf --year 2011 -f cves cvrf_url bug_ids summary product_names
+              openVulnQuery --config PathToCredentialsFile --cvrf --any API filter -f or --fields list of fields separated by space
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --all -f sir bug_ids cves vuln_title
+              >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2011 -f cves cvrf_url bug_ids summary product_names
 ```
 
 ##### Additional Filters
 User can be more specific on filtering advisories when searching all advisories or by severity. They can filter based on last updated and first published dates providing start and end date as a search range. Dates should be entered in YYYY-MM-DD format.
 ```
->> openVulnQuery --cvrf --severity high --last_updated 2016-01-02:2016-04-02 --json filename.json
->> openVulnQuery --cvrf --all --last_updated 2016-01-02:2016-07-02
->> openVulnQuery --cvrf --severity critical --first_published 2015-01-02:2015-01-04
+>> openVulnQuery --config PathToCredentialsFile --cvrf --severity high --last_updated 2016-01-02:2016-04-02 --json filename.json
+>> openVulnQuery --config PathToCredentialsFile --cvrf --all --last_updated 2016-01-02:2016-07-02
+>> openVulnQuery --config PathToCredentialsFile --cvrf --severity critical --first_published 2015-01-02:2015-01-04
 ```
 
 #### Output Format (Optional)
@@ -178,17 +210,17 @@ User can be more specific on filtering advisories when searching all advisories 
 Default
         Table style printed to screen
         Example:
-        >> openVulnQuery --cvrf --year 2016
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2016
 
 --json file path
         Returns json in a file in the specified path
         Example:
-        >> openVulnQuery --cvrf --year 2016 --json  /Users/bkorabik/Documents/2016_cvrf.json
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2016 --json  /Users/bkorabik/Documents/2016_cvrf.json
 
 --csv file path
         Creates a CSV file in the specified path
         Example:
-        >> openVulnQuery --cvrf --year 2016 --csv  /Users/bkorabik/Documents/2016_cvrf.csv
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2016 --csv  /Users/bkorabik/Documents/2016_cvrf.csv
 ```
 #### Count (Optional)
 Returns the count of fields entered with -f or --fields. If no fields are entered the base API fields are counted and displayed
@@ -196,8 +228,8 @@ Returns the count of fields entered with -f or --fields. If no fields are entere
 -c
 
         Examples:
-        >> openVulnQuery --cvrf --year 2016 -c
-        >> openVulnQuery --cvrf --severity low -f sir cves bug_ids -c
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2016 -c
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --severity low -f sir cves bug_ids -c
 ```
 
 #### Developers
@@ -213,8 +245,8 @@ No support for filtering based on --API fields, you can't use --year 2016 and --
 Filtering with Grep:
 ```
 Finding the Number of CVRF Advisories with a "Critical" sir in 2013
-        >> openVulnQuery --cvrf --year 2013 -f sir | grep -c "Critical"
-        >> openVulnQuery --cvrf --severity critical -f first_published | grep -c "2013"
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --year 2013 -f sir | grep -c "Critical"
+        >> openVulnQuery --config PathToCredentialsFile --cvrf --severity critical -f first_published | grep -c "2013"
 ```
 
 If more than one API filter is entered, the last filter will be used for the API call.
@@ -222,7 +254,7 @@ If more than one API filter is entered, the last filter will be used for the API
 You can alternatively use the date range functionality, as shown below:
 
 ```
->> openVulnQuery --cvrf --severity critical --first_published 2015:01:02:2015-01-01
+>> openVulnQuery --config PathToCredentialsFile --cvrf --severity critical --first_published 2015:01:02:2015-01-01
 ```
 
 #### Run OpenVulnQuery as a Library
@@ -290,3 +322,12 @@ Here are the information stored in advisory object.
         * first_fixed
         * cvrf_url
         * oval_url
+
+
+### Running the tests
+
+To run the tests in the tests folder, the additional required `mock` module should be installed inside the `venv`with the usual:
+
+```
+pip install mock
+```

--- a/openVulnQuery/openVulnQuery/advisory.py
+++ b/openVulnQuery/openVulnQuery/advisory.py
@@ -1,4 +1,14 @@
 from abc import ABCMeta
+from platform import python_version_tuple as p_v_t
+
+import constants
+__is_future_version = False if int(p_v_t()[0]) < 3 else True
+
+# noinspection PyCompatibility
+base_str = (str, bytes, bytearray) if __is_future_version else basestring
+
+NA = constants.NA_INDICATOR
+IPS_SIG = constants.IPS_SIGNATURE_LABEL
 
 
 class Filterable(object):
@@ -9,7 +19,10 @@ class Filterable(object):
         for arg in args:
             if hasattr(self, arg):
                 attr = getattr(self, arg)
-                if isinstance(attr, list) and attr and isinstance(attr[0], Filterable):
+                if all([isinstance(attr, list),  # A list
+                        attr,  # Not empty
+                        isinstance(attr[0], Filterable)  # First is our 'type'
+                        ]):
                     filtered_dict[arg] = [a.filter(*args) for a in attr]
                 else:
                     filtered_dict[arg] = attr
@@ -22,7 +35,8 @@ class Advisory(Filterable):
     __metaclass__ = ABCMeta
 
     def __init__(self, advisory_id, sir, first_published, last_updated, cves,
-                 bug_ids, cvss_base_score, advisory_title, publication_url, cwe,
+                 bug_ids, cvss_base_score, advisory_title, publication_url,
+                 cwe,
                  product_names, summary):
         self.advisory_id = advisory_id
         self.sir = sir
@@ -42,8 +56,12 @@ class CVRF(Advisory):
     """CVRF object inherits from Advisory"""
 
     def __init__(self, *args, **kwargs):
-        self.cvrf_url = kwargs.pop('cvrf_url', None)
-        self.ips_signatures = [IPSSignature(**kw) if not isinstance(kw, basestring) else "NA" for kw in kwargs.pop('ips_signatures', None)]
+        self.cvrf_url = kwargs.pop('cvrf_url')
+        self.ips_signatures = []
+        if IPS_SIG in kwargs:
+            self.ips_signatures = [
+                IPSSignature(**kw) if not isinstance(kw, base_str) else NA
+                for kw in kwargs.pop(IPS_SIG)]
         super(CVRF, self).__init__(*args, **kwargs)
 
 
@@ -51,8 +69,12 @@ class OVAL(Advisory):
     """OVAL object as an Advisory"""
 
     def __init__(self, *args, **kwargs):
-        self.oval_url = kwargs.pop('oval_url', None)
-        self.ips_signatures = [IPSSignature(**kw) if not isinstance(kw, basestring) else "NA" for kw in kwargs.pop('ips_signatures', None)]
+        self.oval_url = kwargs.pop('oval_url')
+        self.ips_signatures = []
+        if IPS_SIG in kwargs:
+            self.ips_signatures = [
+                IPSSignature(**kw) if not isinstance(kw, base_str) else NA
+                for kw in kwargs.pop(IPS_SIG)]
         super(OVAL, self).__init__(*args, **kwargs)
 
 
@@ -60,19 +82,78 @@ class AdvisoryIOS(Advisory):
     """Advisory Object with additional information on IOS/IOSXE version """
 
     def __init__(self, *args, **kwargs):
-        self.first_fixed = kwargs.pop('first_fixed', None)
-        self.ios_release = kwargs.pop('ios_release', None)
-        self.oval_url = kwargs.pop('oval_url', None)
-        self.cvrf_url = kwargs.pop('cvrf_url', None)
+        self.first_fixed = kwargs.pop('first_fixed')
+        self.ios_release = kwargs.pop('ios_release')
+        self.oval_url = kwargs.pop('oval_url')
+        self.cvrf_url = kwargs.pop('cvrf_url')
         super(AdvisoryIOS, self).__init__(*args, **kwargs)
 
 
 class IPSSignature(Filterable):
-
-    def __init__(self, legacyIpsId, releaseVersion, softwareVersion, legacyIpsUrl):
+    def __init__(self, legacyIpsId, releaseVersion, softwareVersion,
+                 legacyIpsUrl):
         self.legacy_ips_id = legacyIpsId
         self.release_version = releaseVersion
         self.software_version = softwareVersion
         self.legacy_ips_url = legacyIpsUrl
 
 
+def advisory_factory(adv_data, adv_format, logger):
+    """Converts json into a list of advisory objects.
+    :param adv_data: A dictionary describing an advisory.
+    :param adv_format: The target format in ('cvrf', 'oval', 'ios')
+    :param logger: A logger (for now expecting to be ready to log)
+    :returns advisory instance according to adv_format
+    """
+    if adv_format not in ('cvrf', 'opal', 'ios'):
+        raise ValueError(
+            "Format {} not implemented in advisories".format(adv_format))
+
+    advisory_factory_map = {
+        'cvrf': CVRF,
+        'opal': OVAL,
+        'ios': AdvisoryIOS,
+    }
+
+    adv = adv_data
+    adv_map = {
+        'advisory_id': adv_data["advisoryId"],
+        'sir': adv_data["sir"],
+        'first_published': adv_data["firstPublished"],
+        'last_updated': adv_data["lastUpdated"],
+        'cves': adv_data["cves"],
+        # Empty Union Variant Slot x_url
+        'bug_ids': adv_data["bugIDs"],
+        'cvss_base_score': adv_data["cvssBaseScore"],
+        'advisory_title': adv_data["advisoryTitle"],
+        'publication_url': adv_data["publicationUrl"],
+        'cwe': adv_data["cwe"],
+        'product_names': adv_data["productNames"],
+        'summary': adv_data["summary"],
+        # Pending Variant Slot ips or x_fixed/x_release
+
+    }
+    if adv_format == 'cvrf':
+        adv_map['cvrf_url'] = adv_data["cvrfUrl"]  # Variant::Union
+        # cvrf and oval only attributes:
+        adv_map[IPS_SIG] = adv_data["ipsSignatures"]
+    else:  # implicit 'ios' flavor/format
+        if 'oval' in adv_data:
+            oval_url = adv_data['oval']
+        else:
+            oval_url = adv_data['ovalUrl']
+        if adv_format == "oval":
+            adv_map['oval_url'] = oval_url  # Variant::Union
+            # cvrf and oval only attributes:
+            adv_map['ips_signatures'] = adv_data["ipsSignatures"]
+        else:  # TODO, was 'if not adv_format:', verify that OK
+            adv_map['oval_url'] = oval_url  # Variant::Union
+            # neither cvrf nor oval only attributes:
+            adv_map['first_fixed'] = adv_data["firstFixed"]
+            adv_map['ios_release'] = adv_data["iosRelease"]
+
+    an_adv = advisory_factory_map[adv_format](**adv_map)
+    logger.debug(
+        "{} Advisory {} Created".format(adv_format, an_adv.advisory_id))
+
+    return an_adv

--- a/openVulnQuery/openVulnQuery/authorization.py
+++ b/openVulnQuery/openVulnQuery/authorization.py
@@ -15,9 +15,10 @@ def get_oauth_token(client_id, client_secret):
         If requests exhibits anything other than a 200 response.
 
     """
-    payload = {'client_id': client_id, 'client_secret': client_secret}
-    data = {'grant_type': 'client_credentials'}
-    r = requests.post(config.REQUEST_TOKEN_URL, params=payload, data=data)
+    r = requests.post(
+        config.REQUEST_TOKEN_URL,
+        params={'client_id': client_id, 'client_secret': client_secret},
+        data={'grant_type': 'client_credentials'}
+    )
     r.raise_for_status()
-    resp = r.json()
-    return resp['access_token']
+    return r.json()['access_token']

--- a/openVulnQuery/openVulnQuery/cli_api.py
+++ b/openVulnQuery/openVulnQuery/cli_api.py
@@ -1,0 +1,256 @@
+import argparse
+import constants
+import datetime as dt
+
+
+# Validator function required before referencing:
+def valid_date(date_text):
+    date_parser_format = '%Y-%m-%d'
+    try:
+        start_date, end_date = date_text.split(':')
+        start_date_obj = dt.datetime.strptime(start_date, date_parser_format)
+        end_date_obj = dt.datetime.strptime(end_date, date_parser_format)
+        if start_date_obj > end_date_obj:
+            raise argparse.ArgumentTypeError(
+                'StartDate(%s) should me smaller than EndDate(%s)' % (
+                    start_date, end_date))
+        momentarily = dt.datetime.now()
+        if start_date_obj > momentarily or end_date_obj > momentarily:
+            raise argparse.ArgumentTypeError('Invalid date %s' % date_text)
+        return start_date, end_date
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            '%s is not a valid date format. Enter date in'
+            ' YYYY-MM-DD:YYYY-MM-DD format' % date_text)
+
+
+# CLI_API_ASPECT = (  # Code is data is code is data is code is ...
+#     {
+#         'action': 'an_argparse_action',
+#         'choices': 'argparse_choices',
+#         'const': 'an_argparse_const',
+#         'dest': 'an_argparse_dest',
+#         'help': ('an_argparse_help'),
+#         'metavar': 'an_argparse_metavar',
+#         'nargs': 'an_argparse_nargs',
+#         'tokens': ('-a', '--abstract'),
+#         'type': 'an_argparse_type',
+#     },
+# )  # Above structures can be fed into argparse parser construction.
+
+CLI_API_ADVISORY_FORMAT = (
+    {
+        'action': 'store_const',
+        'const': 'cvrf',
+        'dest': 'advisory_format',
+        'help': (
+            'Selects from cvrf advisories, required except for ios and ios_xe'
+            ' query'),
+        'tokens': ('--cvrf',),
+    },
+    {
+        'action': 'store_const',
+        'const': 'oval',
+        'dest': 'advisory_format',
+        'help': (
+            'Selects from oval advisories, required except for ios and ios_xe'
+            ' query'),
+        'tokens': ('--oval',),
+    },
+)
+
+CLI_API_API_RESOURCE = (
+    {
+        'action': 'store_const',
+        'const': ('all', 'all'),
+        'dest': 'api_resource',
+        'help': 'Retrieve all cvrf/oval advisiories',
+        'tokens': ('--all',),
+    },
+    {
+        'dest': 'api_resource',
+        'help': 'Retrieve advisories by advisory id',
+        'metavar': '<advisory-id>',
+        'tokens': ('--advisory',),
+        'type': (lambda x: ('advisory', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': 'Retrieve advisories by cve id',
+        'metavar': '<CVE-id>',
+        'tokens': ('--cve',),
+        'type': (lambda x: ('cve', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': 'Retrieve latest (number) of advisories',
+        'metavar': 'number',
+        'tokens': ('--latest',),
+        'type': (lambda x: ('latest', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': (
+            'Retrieve advisories by severity (low, medium, high, critical)'),
+        'metavar': '[critical, high, medium, low]',
+        'tokens': ('--severity',),
+        'type': (lambda x: ('severity', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': 'Retrieve advisories by year',
+        'metavar': 'year',
+        'tokens': ('--year',),
+        'type': (lambda x: ('year', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': 'Retrieve advisories by product names',
+        'metavar': 'product_name',
+        'tokens': ('--product',),
+        'type': (lambda x: ('product', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': (
+            'Retrieve advisories affecting user inputted ios_xe version.'
+            'Only one version at a time is allowed.'),
+        'metavar': 'iosxe_version',
+        'tokens': ('--ios_xe',),
+        'type': (lambda x: ('ios_xe', x)),
+    },
+    {
+        'dest': 'api_resource',
+        'help': (
+            'Retrieve advisories affecting user inputted ios version.'
+            'Only one version at a time is allowed.'),
+        'metavar': 'ios_version',
+        'tokens': ('--ios',),
+        'type': (lambda x: ('ios', x)),
+    },
+)
+
+CLI_API_OUTPUT_FORMAT = (
+    {
+        'dest': 'output_format',
+        'help': 'Output to CSV with file path',
+        'metavar': 'filepath',
+        'tokens': ('--csv',),
+        'type': (lambda x: ('csv', x)),
+    },
+    {
+        'dest': 'output_format',
+        'help': 'Output to JSON with file path',
+        'metavar': 'filepath',
+        'tokens': ('--json',),
+        'type': (lambda x: ('json', x)),
+    },
+)
+
+CLI_API_ADDITIONAL_FILTERS = (
+    {
+        'dest': 'first_published',
+        'help': (
+            'Filter advisories based on first_published date'
+            ' YYYY-MM-DD:YYYY-MM-DD USAGE: followed by severity or all'),
+        'metavar': 'YYYY-MM-DD:YYYY-MM-DD',
+        'tokens': ('--first_published',),
+        'type': valid_date,
+    },
+    {
+        'dest': 'last_published',
+        'help': (
+            'Filter advisories based on last_published date'
+            ' YYYY-MM-DD:YYYY-MM-DD USAGE: followed by severity or all'),
+        'metavar': 'YYYY-MM-DD:YYYY-MM-DD',
+        'tokens': ('--last_published',),
+        'type': valid_date,
+    },
+)
+
+CLI_API_PARSER_GENERIC = (
+    {
+        'action': 'store_true',
+        'dest': 'count',  # TODO made destination explicit, verify that OK
+        'help': 'Count of any field or fields',
+        'tokens': ('-c', '--count'),  # TODO reversed order, verify that OK
+    },
+    {
+        'choices': constants.API_LABELS + constants.IPS_SIGNATURES,
+        'dest': 'fields',
+        'help': ('Separate fields by spaces to return advisory information.'
+                 ' Allowed values are: %s' % ', '.join(constants.API_LABELS)),
+        'metavar': '',
+        'nargs': '+',
+        'tokens': ('-f', '--fields'),  # TODO reversed order, verify that OK
+    },
+    {
+        'dest': 'user_agent',
+        'help': ('Announced User-Agent hedar value (towards service)'),
+        'metavar': 'string',
+        'tokens': ('--user-agent',),
+    },
+)
+
+CLI_API_CONFIG = (
+    {
+        'dest': 'json_config_path',
+        'help': ('Path to JSON file with config'),
+        'metavar': 'filepath',
+        'tokens': ('--config',),
+    },
+)
+
+
+def add_options_to_parser(option_parser, options_add_map):
+    """Centralized default option provider for parser (dialect optparse).
+
+    :param option_parser: An instance of argparse.ArgumentParser (for now)
+        which will be enriched (cf. option_add_map) and returned.
+    :param options_add_map: A sequence of dicts with the latter providing per
+        option at least:
+        - 'tokens' the seq of strings providing the option,
+        - 'dest' providing the target  variable/member string name, and
+        - 'help' having a string value.
+    :return the parser object (Note: Mutates object anyhow => for DRY 'nuff)
+    """
+
+    if not isinstance(option_parser, (argparse.ArgumentParser,
+                                      argparse._MutuallyExclusiveGroup)):
+        raise NotImplementedError(
+            "Please provide an argparse.ArgumentParser instance, received %s"
+            "" % (type(option_parser),))
+
+    for options in options_add_map:
+        tokens = options['tokens']
+        option_cfg = {k: v for k, v in options.items() if k != 'tokens'}
+        option_parser.add_argument(*tokens, **option_cfg)
+    return option_parser
+
+
+def parser_factory():
+    """Knit CLI API together and produce an argparse based parser."""
+    p = argparse.ArgumentParser(
+        prog='openVulnQuery',
+        description='Cisco OpenVuln API Command Line Interface')
+    p.set_defaults(output_format=('json', None))
+
+    add_options_to_parser(
+        p.add_mutually_exclusive_group(required=False),
+        CLI_API_ADVISORY_FORMAT)
+
+    add_options_to_parser(
+        p.add_mutually_exclusive_group(required=True), CLI_API_API_RESOURCE)
+
+    add_options_to_parser(
+        p.add_mutually_exclusive_group(), CLI_API_OUTPUT_FORMAT)
+
+    add_options_to_parser(
+        p.add_mutually_exclusive_group(), CLI_API_ADDITIONAL_FILTERS)
+
+    add_options_to_parser(p, CLI_API_PARSER_GENERIC)
+
+    add_options_to_parser(
+        p.add_mutually_exclusive_group(required=True), CLI_API_CONFIG)
+
+    return p

--- a/openVulnQuery/openVulnQuery/config.py
+++ b/openVulnQuery/openVulnQuery/config.py
@@ -4,4 +4,3 @@ CLIENT_SECRET = ""
 
 REQUEST_TOKEN_URL = "https://cloudsso.cisco.com/as/token.oauth2"
 API_URL = "https://api.cisco.com/security/advisories"
-

--- a/openVulnQuery/openVulnQuery/constants.py
+++ b/openVulnQuery/openVulnQuery/constants.py
@@ -1,8 +1,35 @@
-API_LABELS = ['advisory_id', 'sir', 'first_published', 'last_updated', 'cves', 'cvss_base_score',
-              'advisory_title', 'publication_url', 'cwe', 'product_names', 'summary',
-              'oval_url', 'cvrf_url', 'bug_ids', 'ios_release', 'first_fixed', 'ips_signatures']
-IPS_SIGNATURES = ['legacy_ips_id', 'release_version', 'software_version', 'legacy_ips_url']
+IPS_SIGNATURE_LABEL = 'ips_signatures'
 
+API_LABELS = (
+    'advisory_id',
+    'advisory_title',
+    'bug_ids',
+    'cves',
+    'cvrf_url',
+    'cvss_base_score',
+    'cwe',
+    'first_fixed',
+    'first_published',
+    'ios_release',
+    IPS_SIGNATURE_LABEL,
+    'last_updated',
+    'oval_url',
+    'product_names',
+    'publication_url',
+    'sir',
+    'summary',
+)
 
-allows_filter = ['all', 'severity']
+IPS_SIGNATURES = (
+    'legacy_ips_id',
+    'legacy_ips_url',
+    'release_version',
+    'software_version',
+)
 
+ALLOWS_FILTER = (
+    'all',
+    'severity',
+)
+
+NA_INDICATOR = 'NA'

--- a/openVulnQuery/openVulnQuery/main.py
+++ b/openVulnQuery/openVulnQuery/main.py
@@ -1,6 +1,7 @@
-import argparse
-import datetime
+import json
+import os
 
+import cli_api
 import config
 import constants
 import query_client
@@ -8,164 +9,82 @@ import utils
 
 
 def process_command_line():
-    """Interpret parameters in command line"""
+    """Interpret parameters given in command line."""
 
-    parser = argparse.ArgumentParser(prog='openVulnQuery', description='Cisco OpenVuln API Command Line Interface')
-    parser.set_defaults(output_format=('json', None))
-
-    advisory_format = parser.add_mutually_exclusive_group(required=False)
-    api_resource = parser.add_mutually_exclusive_group(required=True)
-    output_format = parser.add_mutually_exclusive_group()
-    additional_filter = parser.add_mutually_exclusive_group()
-
-    advisory_format.add_argument('--cvrf',
-                                 action='store_const',
-                                 const='cvrf',
-                                 dest='advisory_format',
-                                 help='Selects from cvrf advisories, required except for ios and ios_xe query')
-    advisory_format.add_argument('--oval',
-                                 action='store_const',
-                                 const='oval',
-                                 dest='advisory_format',
-                                 help='Selects from oval advisories, required except for ios and ios_xe query')
-
-    api_resource.add_argument('--all',
-                              action='store_const',
-                              const=('all', 'all'),
-                              dest='api_resource',
-                              help='Retrieve all cvrf/oval advisiories')
-    api_resource.add_argument('--advisory',
-                              dest='api_resource',
-                              metavar='<advisory-id>',
-                              type=(lambda x: ('advisory', x)),
-                              help='Retrieve advisories by advisory id')
-    api_resource.add_argument('--cve',
-                              dest='api_resource',
-                              metavar='<CVE-id>',
-                              type=(lambda x: ('cve', x)),
-                              help='Retrieve advisories by cve id')
-    api_resource.add_argument('--latest',
-                              dest='api_resource',
-                              metavar='number',
-                              type=(lambda x: ('latest', x)),
-                              help='Retrieve latest (number) of advisories')
-    api_resource.add_argument('--severity',
-                              dest='api_resource',
-                              metavar='[critical, high, medium, low]',
-                              type=(lambda x: ('severity', x)),
-                              help='Retrieve advisories by severity (low, medium, high, critical)')
-    api_resource.add_argument('--year',
-                              dest='api_resource',
-                              metavar='year',
-                              type=(lambda x: ('year', x)),
-                              help='Retrieve advisories by year')
-
-    api_resource.add_argument('--product',
-                              dest='api_resource',
-                              metavar='product_name',
-                              type=(lambda x: ('product', x)),
-                              help='Retrieve advisories by product names')
-    api_resource.add_argument('--ios_xe',
-                              dest='api_resource',
-                              metavar='iosxe_version',
-                              type=(lambda x: ('ios_xe', x)),
-                              help='Retrieve advisories affecting user inputted ios_xe version.'
-                                   'Only one version at a time is allowed.')
-    api_resource.add_argument('--ios',
-                              dest='api_resource',
-                              metavar='ios_version',
-                              type=(lambda x: ('ios', x)),
-                              help='Retrieve advisories affecting user inputted ios version.'
-                                   'Only one version at a time is allowed.')
-    output_format.add_argument('--csv',
-                               dest='output_format',
-                               metavar='filepath',
-                               type=(lambda x: ('csv', x)),
-                               help='Output to CSV with file path')
-    output_format.add_argument('--json',
-                               dest='output_format',
-                               metavar='filepath',
-                               type=(lambda x: ('json', x)),
-                               help='Output to JSON with file path')
-    additional_filter.add_argument('--first_published',
-                                   dest='first_published',
-                                   metavar='YYYY-MM-DD:YYYY-MM-DD',
-                                   type=valid_date,
-                                   help='Filter advisories based on first_published date YYYY-MM-DD:YYYY-MM-DD'
-                                        ' USAGE: followed by severity or all')
-    additional_filter.add_argument('--last_published',
-                                   dest='last_published',
-                                   metavar='YYYY-MM-DD:YYYY-MM-DD',
-                                   type=valid_date,
-                                   help='Filter advisories based on last_published date YYYY-MM-DD:YYYY-MM-DD'
-                                        ' USAGE: followed by severity or all')
-
-    parser.add_argument('--count', '-c',
-                        action='store_true',
-                        help='Count of any field or fields')
-    parser.add_argument('--fields', '-f',
-                        dest='fields',
-                        nargs='+',
-                        metavar='',
-                        choices=constants.API_LABELS + constants.IPS_SIGNATURES,
-                        help='Separate fields by spaces to return advisory information. Allowed values are: %s' % ', '.join(constants.API_LABELS))
+    parser = cli_api.parser_factory()
 
     args = parser.parse_args()
     if not args.advisory_format:
         key, val = args.api_resource
         if key not in ['ios', 'ios_xe']:
-            parser.error('Advisory format --cvrf or --oval required except for ios and ios_xe')
+            parser.error('Advisory format --cvrf or --oval required except for'
+                         ' ios and ios_xe')
 
-    if args.api_resource[0] not in constants.allows_filter:
+    if args.api_resource[0] not in constants.ALLOWS_FILTER:
         if args.first_published or args.last_published:
-            parser.error('Only %s based filter can have additional first_published or last_published filter' % constants.allows_filter)
+            parser.error(
+                'Only %s based filter can have additional first_published or'
+                ' last_published filter' % constants.ALLOWS_FILTER)
+
+    if not args.json_config_path:
+        parser.error(
+            ' --conf <FILE> ? Missing configuration file (with credentials)')
+    else:
+        if not os.path.isfile(args.json_config_path):
+            parser.error(
+                'Configuration file not found at %s' % args.json_config_path)
+        else:
+            parsed_config = json.load(open(args.json_config_path))
+            keys_required = ('CLIENT_ID', 'CLIENT_SECRET')
+            for key in keys_required:
+                setattr(config, key, parsed_config[key])
+            keys_optional = ('REQUEST_TOKEN_URL', 'API_URL')
+            for key in keys_optional:
+                if key in parsed_config:
+                    setattr(config, key, parsed_config[key])
+
     return args
 
 
-def valid_date(date_text):
-    try:
-        start_date, end_date = date_text.split(':')
-        start_date_obj = datetime.datetime.strptime(start_date, '%Y-%m-%d')
-        end_date_obj = datetime.datetime.strptime(end_date, '%Y-%m-%d')
-        if start_date_obj > end_date_obj:
-            raise argparse.ArgumentTypeError('StartDate(%s) should me smaller than EndDate(%s)' % (start_date, end_date))
-        if start_date_obj > datetime.datetime.now() or end_date_obj > datetime.datetime.now():
-            raise argparse.ArgumentTypeError('Invalid date %s' % date_text)
-        return start_date, end_date
-    except ValueError:
-        raise argparse.ArgumentTypeError('%s is not a valid date format. Enter date in YYYY-MM-DD:YYYY-MM-DD format' % date_text)
-
-
 def main():
-
     args = process_command_line()
     api_resource_key, api_resource_value = args.api_resource
 
-    client = query_client.OpenVulnQueryClient(config.CLIENT_ID, config.CLIENT_SECRET)
+    client_cfg = {
+        'client_id': config.CLIENT_ID,
+        'client_secret': config.CLIENT_SECRET
+    }
+    if args.user_agent:
+        client_cfg['user_agent'] = args.user_agent
+    client = query_client.OpenVulnQueryClient(**client_cfg)
     query_client_func = getattr(client, 'get_by_{0}'.format(api_resource_key))
     if not args.advisory_format:
         advisories = query_client_func(api_resource_value)
     else:
-        if api_resource_key in constants.allows_filter:
-            filter = query_client.Filter()
+        if api_resource_key in constants.ALLOWS_FILTER:
+            a_filter = query_client.Filter()
             if args.first_published:
                 start_date, end_date = args.first_published
-                filter = query_client.FirstPublishedFilter(start_date, end_date)
+                a_filter = query_client.FirstPublishedFilter(
+                    start_date, end_date)
             elif args.last_published:
                 start_date, end_date = args.last_published
-                filter = query_client.LastPublishedFilter(start_date, end_date)
-            advisories = query_client_func(args.advisory_format, api_resource_value, filter)
+                a_filter = query_client.LastPublishedFilter(
+                    start_date, end_date)
+            advisories = query_client_func(
+                args.advisory_format, api_resource_value, a_filter)
         else:
-            advisories = query_client_func(args.advisory_format, api_resource_value)
+            advisories = query_client_func(
+                args.advisory_format, api_resource_value)
 
-    returned_output = None
     if args.fields:
         if args.count:
             returned_output = [utils.count_fields(advisories, args.fields)]
         else:
             returned_output = utils.filter_advisories(advisories, args.fields)
     else:
-        returned_output = utils.filter_advisories(advisories, constants.API_LABELS)
+        returned_output = utils.filter_advisories(
+            advisories, constants.API_LABELS)
 
     output_format, file_path = args.output_format
 

--- a/openVulnQuery/openVulnQuery/sample_credentials.json
+++ b/openVulnQuery/openVulnQuery/sample_credentials.json
@@ -1,0 +1,4 @@
+{
+	"CLIENT_ID": "BadCodedBadCodedBadCoded", 
+	"CLIENT_SECRET": "DeadFaceDeadFaceDeadFace"
+}

--- a/openVulnQuery/setup.py
+++ b/openVulnQuery/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='OpenVulnQuery',
-      version='1.23',
+      version='1.24',
       description='A python-based module(s) to query the Cisco PSIRT openVuln API.',
       url='https://github.com/CiscoPSIRT/openVulnAPI/tree/master/openVulnQuery',
       author='Bradley Korabik, Parash Ghimire',
@@ -14,6 +14,6 @@ setup(name='OpenVulnQuery',
           },
       install_requires=[
           'argparse==1.4.0',
-          'requests==2.10.0'
+          'requests>=2.10.0'
       ],
       zip_safe=False,)

--- a/openVulnQuery/tests/test_query_client_cvrf.py
+++ b/openVulnQuery/tests/test_query_client_cvrf.py
@@ -1,9 +1,10 @@
 import json
 import unittest
+
 import mock
-from openVulnQuery import query_client
 from openVulnQuery import advisory
 from openVulnQuery import config
+from openVulnQuery import query_client
 
 API_URL = "https://api.cisco.com/security/advisories"
 test_advisory_id = "Cisco-SA-20111107-CVE-2011-0941"
@@ -113,13 +114,14 @@ response_advisory_id = """{
 def mocked_get_requests(*args, **kwargs):
     """Mocks requests get method from QueryClient"""
 
-    url = "{base_url}/{path}".format(base_url = API_URL,
-                                     path = args[0])
-    return mocked_requests_lib_get(url = url).json()
+    url = "{base_url}/{path}".format(
+        base_url=API_URL, path=args[0])
+    return mocked_requests_lib_get(url=url).json()
 
 
 def mocked_requests_lib_get(*args, **kwargs):
     """Mocks library requests.get method"""
+
     class MockResponse():
         def __init__(self, status_code, json_response):
             self.status_code = status_code
@@ -137,7 +139,8 @@ def mocked_requests_lib_get(*args, **kwargs):
     if API_URL in kwargs["url"]:
         if "advisory" in kwargs["url"]:
             return MockResponse(200, response_advisory_id)
-        elif any(x in kwargs["url"] for x in ("cve", "severity", "year", "all")):
+        elif any(x in kwargs["url"] for x in
+                 ("cve", "severity", "year", "all")):
             return MockResponse(200, response_generic)
         else:
             return MockResponse(404, response_not_found)
@@ -147,41 +150,50 @@ def mocked_requests_lib_get(*args, **kwargs):
 
 class OpenVulnQueryClientTestCvrf(unittest.TestCase):
     """Unit Test for all function in OpenVulnQueryClient"""
+
     def setUp(self):
-        self.open_vuln_client = query_client.OpenVulnQueryClient(config.CLIENT_ID,
-                                                                 config.CLIENT_SECRET)
+        self.open_vuln_client = query_client.OpenVulnQueryClient(
+            config.CLIENT_ID,
+            config.CLIENT_SECRET)
         self.adv_format = "cvrf"
 
-
-    @mock.patch("query_client.OpenVulnQueryClient.get_request", side_effect=mocked_get_requests)
+    @mock.patch("query_client.OpenVulnQueryClient.get_request",
+                side_effect=mocked_get_requests)
     def test_get_by_cve(self, mock_get_requests):
         """Checks if get_by_cve function calls request args with correct arguments"""
         exp_args = "cvrf/cve/%s" % test_cve
         response = self.open_vuln_client.get_by_cve(self.adv_format, test_cve)
         mock_get_requests.assert_called_with(exp_args)
 
-    @mock.patch("query_client.OpenVulnQueryClient.get_request", side_effect=mocked_get_requests)
+    @mock.patch("query_client.OpenVulnQueryClient.get_request",
+                side_effect=mocked_get_requests)
     def test_get_by_advisory(self, mock_get_requests):
         """Checks if get_by_advisory function calls request args with correct arguments"""
         exp_args = "cvrf/advisory/%s" % test_advisory_id
-        response = self.open_vuln_client.get_by_advisory(self.adv_format, test_advisory_id)
+        response = self.open_vuln_client.get_by_advisory(self.adv_format,
+                                                         test_advisory_id)
         mock_get_requests.assert_called_with(exp_args)
 
-    @mock.patch("query_client.OpenVulnQueryClient.get_request", side_effect=mocked_get_requests)
+    @mock.patch("query_client.OpenVulnQueryClient.get_request",
+                side_effect=mocked_get_requests)
     def test_get_by_year(self, mock_get_requests):
         """Checks if get_by_year function calls request args with correct arguments"""
         exp_args = "cvrf/year/%s" % test_year
-        response = self.open_vuln_client.get_by_year(self.adv_format, year = test_year)
+        response = self.open_vuln_client.get_by_year(self.adv_format,
+                                                     year=test_year)
         mock_get_requests.assert_called_with(exp_args)
 
-    @mock.patch("query_client.OpenVulnQueryClient.get_request", side_effect=mocked_get_requests)
+    @mock.patch("query_client.OpenVulnQueryClient.get_request",
+                side_effect=mocked_get_requests)
     def test_get_by_severity(self, mock_get_requests):
         """Checks if get_by_severity function calls request args with correct arguments"""
         exp_args = "cvrf/severity/%s" % test_severity
-        response = self.open_vuln_client.get_by_severity(self.adv_format, severity=test_severity)
+        response = self.open_vuln_client.get_by_severity(self.adv_format,
+                                                         severity=test_severity)
         mock_get_requests.assert_called_with(exp_args)
 
-    @mock.patch("query_client.OpenVulnQueryClient.get_request", side_effect=mocked_get_requests)
+    @mock.patch("query_client.OpenVulnQueryClient.get_request",
+                side_effect=mocked_get_requests)
     def test_get_by_all(self, mock_get_requests):
         """Checks if get_by_all function calls request args with correct arguments"""
         exp_args = "cvrf/all"
@@ -199,12 +211,14 @@ class OpenVulnQueryClientTestCvrf(unittest.TestCase):
     def test_get_requests_invalid_path(self, mock_get):
         """Checks if get_by_cve function raises exception for bad url path"""
         invalid_test_path = "cvrf/cvoo/%s" % test_cve
-        self.assertRaises(Exception, self.open_vuln_client.get_request, invalid_test_path)
+        self.assertRaises(Exception, self.open_vuln_client.get_request,
+                          invalid_test_path)
 
     def test_advisory_list(self):
         advisories = json.loads(response_generic)["advisories"]
         advs = self.open_vuln_client.advisory_list(advisories, self.adv_format)
-        self.assertIsInstance(advs[0], advisory.CVRF, "This object is not instance of Advisory")
+        self.assertIsInstance(advs[0], advisory.CVRF,
+                              "This object is not instance of Advisory")
 
 
 if __name__ == "__main__":

--- a/openVulnQuery/tests/test_utils.py
+++ b/openVulnQuery/tests/test_utils.py
@@ -1,21 +1,29 @@
 import unittest
+from openVulnQuery import constants
 from openVulnQuery import utils
 from openVulnQuery import advisory
 
+NA = constants.NA_INDICATOR
 mock_advisory_title = "Mock Advisory Title"
-mock_advisory = advisory.CVRF(advisory_id="Cisco-SA-20111107-CVE-2011-0941",
-                              sir="Medium",
-                              first_published="2011-11-07T21:36:55+0000",
-                              last_updated="2011-11-07T21:36:55+0000",
-                              cves=["CVE-2011-0941", "NA"],
-                              cvrf_url="http://tools.cisco.com/security/center/contentxml/CiscoSecurityAdvisory/Cisco-SA-20111107-CVE-2011-0941/cvrf/Cisco-SA-20111107-CVE-2011-0941_cvrf.xml",
-                              bug_ids="BUGISidf",
-                              cvss_base_score="7.0",
-                              advisory_title="%s" % mock_advisory_title,
-                              publication_url="https://tools.cisco.com/mockurl",
-                              cwe="NA",
-                              product_names=["product_name_1", "product_name_2"],
-                              summary="This is summary")
+adv_cfg = {
+    'advisory_id': "Cisco-SA-20111107-CVE-2011-0941",
+    'sir': "Medium",
+    'first_published': "2011-11-07T21:36:55+0000",
+    'last_updated': "2011-11-07T21:36:55+0000",
+    'cves': ["CVE-2011-0941", NA],
+    'cvrf_url': (
+        "http://tools.cisco.com/security/center/contentxml/"
+        "CiscoSecurityAdvisory/Cisco-SA-20111107-CVE-2011-0941/cvrf/"
+        "Cisco-SA-20111107-CVE-2011-0941_cvrf.xml"),
+    'bug_ids': "BUGISidf",
+    'cvss_base_score': "7.0",
+    'advisory_title': "{}".format(mock_advisory_title),
+    'publication_url': "https://tools.cisco.com/mockurl",
+    'cwe': NA,
+    'product_names': ["product_name_1", "product_name_2"],
+    'summary': "This is summary"
+}
+mock_advisory = advisory.CVRF(**adv_cfg)
 mock_advisories = [mock_advisory]
 
 
@@ -23,14 +31,18 @@ class UtilsTest(unittest.TestCase):
 
     def test_filter_advisories_general_input(self):
         fields = ["advisory_title", "sir", "bug_ids"]
-        expected_output = [{"advisory_title": "Mock Advisory Title", "sir": "Medium", "bug_ids": "BUGISidf"}]
+        expected_output = [
+            {"advisory_title": "Mock Advisory Title",
+             "sir": "Medium",
+             "bug_ids": "BUGISidf"}]
         output = utils.filter_advisories(mock_advisories, fields)
         self.assertListEqual(output, expected_output)
 
     def test_filter_advisories_empty_fields(self):
         fields = []
         expected_output = [{}]
-        self.assertListEqual(utils.filter_advisories(mock_advisories, fields), expected_output)
+        self.assertListEqual(
+            utils.filter_advisories(mock_advisories, fields), expected_output)
 
     def test_filter_advisories_invalid_fields(self):
         fields = ["advisory_title", "v_score"]
@@ -52,11 +64,11 @@ class UtilsTest(unittest.TestCase):
         self.assertDictEqual(output, expected_output)
 
     def test_get_count_valid(self):
-        self.assertEqual(utils.get_count(getattr(mock_advisory, "advisory_title")), 1)
-        self.assertEqual(utils.get_count(getattr(mock_advisory, "product_names")), 2)
+        self.assertEqual(utils.get_count(
+            getattr(mock_advisory, "advisory_title")), 1)
+        self.assertEqual(utils.get_count(
+            getattr(mock_advisory, "product_names")), 2)
 
     def test_get_count_fields_with_NA(self):
         self.assertEqual(utils.get_count(getattr(mock_advisory, "cwe")), 0)
         self.assertEqual(utils.get_count(getattr(mock_advisory, "cves")), 1)
-
-


### PR DESCRIPTION
I hope the changes are acceptable ;-)

Further detailed changes:
* Added config and user-agent options, 
* Refactored code to better expose CLI API, 
* Updated documentation; 
* Softened/updated dependency on requests; 
* `test_utils.py` passes, 
* pep8 and vulture are happy with the code; 
* Sample call:
 `python ./main.py --config some_configuration.json --year 2017 --json a.json --cvrf`
  succeeds - well; 

**Note**: The other test_query_client_cvrf is not in sync and does **not** look like a unittest, as it really contacts the API URL and uses credentials (for now it fails, when one does not fill in credential values in `config.py`)