### PR TITLE
fixes version mismatch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [Python-based API client (openVulnQuery)](https://github.com/CiscoPSIRT/open
 pip install openVulnQuery
 ```
 
-Depending on your environment, you may need to specify the latest version (1.29), as demonstrated below:
+Depending on your environment, you may need to specify the latest version (1.30), as demonstrated below:
 
 ```
 python3 -m pip install openVulnQuery==1.30


### PR DESCRIPTION
Matches versions between example command and description.

Minor, superficial. Streamlining the process of getting ops to code needs as few bumps as possible though.