### PR TITLE
Check for values in adv_data before accessing

### DIFF
--- a/openVulnQuery/openVulnQuery/_library/advisory.py
+++ b/openVulnQuery/openVulnQuery/_library/advisory.py
@@ -127,7 +127,8 @@ def advisory_factory(adv_data, adv_format, logger):
             adv_map[k] = adv_data[v]
     else:  # IOS advisory format targeted:
         for k, v in IOS_ADD_ONS_MAP.items():
-            adv_map[k] = adv_data[v]
+            if v in adv_data:
+                adv_map[k] = adv_data[v]
 
     an_adv = advisory_format_factory_map()[adv_format](**adv_map)
     logger.debug(


### PR DESCRIPTION
The following advisories cause the tool to crash without this null check:
```
firstFixed not found in adv_data for cisco-sa-20190828-fxnxos-snmp-dos
firstFixed not found in adv_data for cisco-sa-20190828-nxos-api-dos
firstFixed not found in adv_data for cisco-sa-20190828-nxos-fsip-dos
firstFixed not found in adv_data for cisco-sa-20190828-nxos-memleak-dos
firstFixed not found in adv_data for cisco-sa-20190828-nxos-ntp-dos
firstFixed not found in adv_data for cisco-sa-20190925-nxos-vman-cmd-inj
firstFixed not found in adv_data for cisco-sa-20190925-vman
firstFixed not found in adv_data for cisco-sa-20200205-fxnxos-iosxr-cdp-dos
firstFixed not found in adv_data for cisco-sa-20200226-fxos-nxos-cdp
```
Tested using:
`openVulnQuery --config cisco-api.json --nxos="7.3(1)N1(1)"`